### PR TITLE
SV-230251

### DIFF
--- a/controls/SV-230251.rb
+++ b/controls/SV-230251.rb
@@ -24,32 +24,26 @@ can be viewed in the /etc/crypto-policies/back-ends/opensshserver.config file.
 matches the server list. Listing the values "strongest to weakest" is a
 method to ensure the use of the strongest hash available to secure the SSH
 connection.'
-  desc 'check', 'Verify the SSH server is configured to use only MACs employing FIPS
-140-2-approved algorithms with the following command:
+  desc 'check', 'Verify the SSH server is configured to use only MACs employing FIPS 140-2-approved algorithms with the following command:
 
-    $ sudo grep -i macs /etc/crypto-policies/back-ends/opensshserver.config
+     $ sudo grep -i macs /etc/crypto-policies/back-ends/opensshserver.config
 
-    -oMACS=hmac-sha2-512,hmac-sha2-256
+     -oMACS=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
-    If the MACs entries in the "opensshserver.config" file have any hashes
-other than "hmac-sha2-512" and "hmac-sha2-256", the order differs from the
-example above, they are missing, or commented out, this is a finding.'
-  desc 'fix', 'Configure the RHEL 8 SSH server to use only MACs employing FIPS
-140-2-approved algorithms by updating the
-"/etc/crypto-policies/back-ends/opensshserver.config" file with the following
-line:
+If the MACs entries in the "opensshserver.config" file have any hashes other than shown here, the order differs from the example above, or they are missing or commented out, this is a finding.'
+  desc 'fix', 'Configure the RHEL 8 SSH server to use only MACs employing FIPS 140-2-approved algorithms by updating the "/etc/crypto-policies/back-ends/opensshserver.config" file with the following line:
 
-    -oMACS=hmac-sha2-512,hmac-sha2-256
+-oMACS=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
-    A reboot is required for the changes to take effect.'
+A reboot is required for the changes to take effect.'
   impact 0.5
   tag severity: 'medium'
   tag gtitle: 'SRG-OS-000250-GPOS-00093'
   tag satisfies: ['SRG-OS-000250-GPOS-00093', 'SRG-OS-000393-GPOS-00173', 'SRG-OS-000394-GPOS-00174', 'SRG-OS-000125-GPOS-00065']
   tag gid: 'V-230251'
-  tag rid: 'SV-230251r743937_rule'
+  tag rid: 'SV-230251r917870_rule'
   tag stig_id: 'RHEL-08-010290'
-  tag fix_id: 'F-32895r743936_fix'
+  tag fix_id: 'F-32895r917869_fix'
   tag cci: ['CCI-001453']
   tag nist: ['AC-17 (2)']
 

--- a/controls/SV-230251.rb
+++ b/controls/SV-230251.rb
@@ -61,7 +61,7 @@ A reboot is required for the changes to take effect.'
 
     unless crypto_policy.nil?
       describe parse_config(crypto_policy.gsub(/\s|'/, "\n")) do
-        its('-oMACS') { should cmp 'hmac-sha2-512,hmac-sha2-256' }
+        its('-oMACS') { should cmp 'hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com' }
       end
     end
   end

--- a/controls/SV-230251.rb
+++ b/controls/SV-230251.rb
@@ -61,7 +61,7 @@ A reboot is required for the changes to take effect.'
 
     unless crypto_policy.nil?
       describe parse_config(crypto_policy.gsub(/\s|'/, "\n")) do
-        its('-oMACS') { should cmp 'hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com' }
+        its('-oMACs') { should cmp 'hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com' }
       end
     end
   end


### PR DESCRIPTION
- [x] Updated logic to check for additional algorithms, permitted by the V1R12 guidance
- [x] Confirm that the STIG has a typo and it should be -oMACs, not -oMACS. If it is not a typo, this needs a toLower or the like to make it check appropriately in systems with little s and systems with big S