### PR TITLE
SV-230494

### DIFF
--- a/controls/SV-230494.rb
+++ b/controls/SV-230494.rb
@@ -53,7 +53,7 @@ Reboot the system for the settings to take effect.'
       skip 'Control not applicable within a container'
     end
   else
-    describe kernel_module('ATM') do
+    describe kernel_module('atm') do
       it { should be_disabled }
       it { should be_blacklisted }
     end

--- a/controls/SV-230494.rb
+++ b/controls/SV-230494.rb
@@ -12,45 +12,38 @@ additional attack vectors.
 data link, and physical layers, based on virtual circuits and virtual paths.
 Disabling ATM protects the system against exploitation of any laws in its
 implementation.'
-  desc 'check', 'Verify the operating system disables the ability to load the ATM protocol
-kernel module.
+  desc 'check', 'Verify the operating system disables the ability to load the ATM protocol kernel module.
 
-    $ sudo grep -ri ATM /etc/modprobe.d/* | grep -i "/bin/true"
+$ sudo grep -r atm /etc/modprobe.d/* | grep "/bin/true"
 
-    install ATM /bin/true
+install atm /bin/true
 
-    If the command does not return any output, or the line is commented out,
-and use of the ATM protocol is not documented with the Information System
-Security Officer (ISSO) as an operational requirement, this is a finding.
+If the command does not return any output, or the line is commented out, and use of the ATM protocol is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
-    Verify the operating system disables the ability to use the ATM protocol.
+Verify the operating system disables the ability to use the ATM protocol.
 
-    Check to see if the ATM protocol is disabled with the following command:
+Check to see if the ATM protocol is disabled with the following command:
 
-    $ sudo grep -ri ATM /etc/modprobe.d/* | grep -i "blacklist"
+$ sudo grep -r atm /etc/modprobe.d/* | grep "blacklist"
 
-    blacklist ATM
+blacklist atm
 
-    If the command does not return any output or the output is not "blacklist
-atm", and use of the ATM protocol is not documented with the Information
-System Security Officer (ISSO) as an operational requirement, this is a finding.'
-  desc 'fix', 'Configure the operating system to disable the ability to use the ATM
-protocol kernel module.
+If the command does not return any output or the output is not "blacklist atm", and use of the ATM protocol is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.'
+  desc 'fix', 'Configure the operating system to disable the ability to use the ATM protocol kernel module.
 
-    Add or update the following lines in the file
-"/etc/modprobe.d/blacklist.conf":
+Add or update the following lines in the file "/etc/modprobe.d/blacklist.conf":
 
-    install ATM /bin/true
-    blacklist ATM
+install atm /bin/true
+blacklist atm
 
-    Reboot the system for the settings to take effect.'
+Reboot the system for the settings to take effect.'
   impact 0.3
   tag severity: 'low'
   tag gtitle: 'SRG-OS-000095-GPOS-00049'
   tag gid: 'V-230494'
-  tag rid: 'SV-230494r627750_rule'
+  tag rid: 'SV-230494r792911_rule'
   tag stig_id: 'RHEL-08-040021'
-  tag fix_id: 'F-33138r568229_fix'
+  tag fix_id: 'F-33138r792910_fix'
   tag cci: ['CCI-000381']
   tag nist: ['CM-7 a']
 


### PR DESCRIPTION
Updated the kernel_module('ATM') to kernel_module('atm') according to the latest guidance.
Tested on local target rhel8 machine that failed when the check looked at ATM and passed with atm.