### PR TITLE
Fix sv 230464

### DIFF
--- a/controls/SV-230464.rb
+++ b/controls/SV-230464.rb
@@ -59,7 +59,6 @@ auid!=unset -k perm_mod
       expect(audit_rule.action.uniq).to cmp 'always'
       expect(audit_rule.list.uniq).to cmp 'exit'
       expect(audit_rule.fields.flatten).to include('perm=x', 'auid>=1000', 'auid!=-1')
-      expect(audit_rule.key.uniq).to include('perm_mod')
       expect(audit_rule.key.uniq).to include(input('audit_rule_keynames').merge(input('audit_rule_keynames_overrides'))[audit_command])
     end
   end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1022,7 +1022,7 @@ inputs:
       'fchmodat'                      : 'perm_mod',
       '/usr/bin/sudo'                 : 'priv_cmd',
       '/usr/sbin/usermod'             : 'priv_cmd',
-      '/usr/bin/chacl'                : 'priv_mod',
+      '/usr/bin/chacl'                : 'perm_mod',
       '/usr/bin/kmod'                 : 'modules',
       '/var/log/faillock'             : 'logins',
       '/var/log/lastlog'              : 'logins'

--- a/inspec.yml
+++ b/inspec.yml
@@ -8,6 +8,12 @@ version: 1.12.0
 
 inspec_version: ">= 5.0"
 
+supports:
+  - platform-name: centos
+    release: 8.*
+  - platform-name: redhat
+    release: 8.*
+
 ### INPUTS ###
 # Inputs are variables that can be referenced by any control in the profile, 
 # and are defined and given a default value in this file.


### PR DESCRIPTION
There was a conflict in SV-230464:
expect(audit_rule.key.uniq).to include('perm_mod')
expect(audit_rule.key.uniq).to include(input('audit_rule_keynames').merge(input('audit_rule_keynames_overrides'))[audit_command])
Where the inspec.yml defines:
'/usr/bin/chacl' : 'priv_mod',

The 'perm_mod' line be removed, and inspec.yml to update to 'perm_mod'
Otherwise, this control will never pass since they contradict themselves
