### PR TITLE
Adding the amazon 2023.* platform-name to the supports list

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -13,6 +13,8 @@ supports:
     release: 8.*
   - platform-name: redhat
     release: 8.*
+  - platform-name: amazon
+    release: 2023.*
 
 ### INPUTS ###
 # Inputs are variables that can be referenced by any control in the profile, 


### PR DESCRIPTION
AL2023 is based on RHEL8 so this works for AL2023, but it needs the platform name to be present.